### PR TITLE
fix: use correct fossa binary name for bin.install

### DIFF
--- a/fossa.rb
+++ b/fossa.rb
@@ -22,6 +22,6 @@ class Fossa < Formula
   end
 
   def install
-    bin.install "fossa-cli"
+    bin.install "fossa"
   end
 end


### PR DESCRIPTION
Tested locally and this seems to fix it, the issue is the binary name is "fossa" so needed this update.

Fixes https://github.com/fossas/fossa-cli/issues/651