### PR TITLE
fix: update binary installation name

### DIFF
--- a/fossa.rb
+++ b/fossa.rb
@@ -22,6 +22,6 @@ class Fossa < Formula
   end
 
   def install
-    bin.install "fossa-cli"
+    bin.install "fossa"
   end
 end


### PR DESCRIPTION
The binary included in the release package is named `fossa`, not `fossa-cli`.

Diagnosed via `brew install fossa --debug` and inspecting the shell execution environment.

Fixes #2